### PR TITLE
New health endpoint added

### DIFF
--- a/internal/request_handler.go
+++ b/internal/request_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"net/http"
+	"time"
 
 	"github.com/2beens/tiny-api/pkg"
 
@@ -35,6 +36,12 @@ func (h *RequestHandler) HandlePing(w http.ResponseWriter, r *http.Request) {
 
 func (h *RequestHandler) HandleHarakiri(w http.ResponseWriter, r *http.Request) {
 	log.Println("killing myself ...")
+	
+	w.WriteHeader(http.StatusAccepted)
+	w.Write([]byte("killing myself..."))
+	
+	// wait a bit for the response to be sent
+	time.Sleep(time.Second)
 	os.Exit(1)
 }
 

--- a/internal/request_handler.go
+++ b/internal/request_handler.go
@@ -40,9 +40,11 @@ func (h *RequestHandler) HandleHarakiri(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusAccepted)
 	w.Write([]byte("killing myself..."))
 	
-	// wait a bit for the response to be sent
-	time.Sleep(time.Second)
-	os.Exit(1)
+	go func() {
+		// wait a bit for the response to be sent
+		time.Sleep(time.Second)
+		os.Exit(1)		
+	}()
 }
 
 func (h *RequestHandler) HandleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/request_handler.go
+++ b/internal/request_handler.go
@@ -2,9 +2,12 @@ package internal
 
 import (
 	"fmt"
+	"os"
 	"net/http"
 
 	"github.com/2beens/tiny-api/pkg"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type RequestHandler struct {
@@ -28,6 +31,11 @@ func (h *RequestHandler) HandlePing(w http.ResponseWriter, r *http.Request) {
 	pkg.WriteJsonResponse(w, http.StatusOK, pkg.ApiResponse{
 		Message: fmt.Sprintf("%s: PONG!", h.instanceName),
 	})
+}
+
+func (h *RequestHandler) HandleHarakiri(w http.ResponseWriter, r *http.Request) {
+	log.Println("killing myself ...")
+	os.Exit(1)
 }
 
 func (h *RequestHandler) HandleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/request_handler.go
+++ b/internal/request_handler.go
@@ -29,3 +29,8 @@ func (h *RequestHandler) HandlePing(w http.ResponseWriter, r *http.Request) {
 		Message: fmt.Sprintf("%s: PONG!", h.instanceName),
 	})
 }
+
+func (h *RequestHandler) HandleHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}

--- a/internal/server.go
+++ b/internal/server.go
@@ -42,6 +42,7 @@ func (s *Server) routerSetup() *mux.Router {
 	router := mux.NewRouter()
 
 	router.HandleFunc("/ping", s.reqHandler.HandlePing).Methods("GET")
+	router.HandleFunc("/health", s.reqHandler.HandleHealth).Methods("GET")
 	router.HandleFunc("/", s.reqHandler.HandleRootRequest).Methods("GET")
 
 	// add a small middleware function to log request details

--- a/internal/server.go
+++ b/internal/server.go
@@ -43,6 +43,7 @@ func (s *Server) routerSetup() *mux.Router {
 
 	router.HandleFunc("/ping", s.reqHandler.HandlePing).Methods("GET")
 	router.HandleFunc("/health", s.reqHandler.HandleHealth).Methods("GET")
+	router.HandleFunc("/harakiri", s.reqHandler.HandleHarakiri).Methods("GET")
 	router.HandleFunc("/", s.reqHandler.HandleRootRequest).Methods("GET")
 
 	// add a small middleware function to log request details


### PR DESCRIPTION
New endpoints to test and experiment:
 - health check (for [k8s liveness check](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request))
 - breakme - ability to kill the service (and check what happens to pods in that case)